### PR TITLE
Fix Turbo

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">We'll send you an email with confirmation instructions</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
             <%= f.full_error :confirmation_token %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">Please enter your new password below</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
             <%= f.input :reset_password_token, as: :hidden %>
             <%= f.full_error :reset_password_token %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">We'll send you an email to reset your password</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
 
             <div class="mb-4">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,7 +9,7 @@
             <%= link_to "← Back", :back, class: "text-decoration-none" %>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
 
             <div class="mb-4">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">Join the MoFreelance community</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
 
             <%# Using existing Stimulus controller %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">Welcome back to MoFreelance</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), html: { data: { turbo: false } }) do |f| %>
             <div class="form-floating mb-3">
               <%= f.input :email,
                           required: false,

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -9,7 +9,7 @@
             <p class="text-muted">Your account has been locked due to too many failed login attempts</p>
           </div>
 
-          <%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+          <%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
             <%= f.error_notification %>
             <%= f.full_error :unlock_token %>
 


### PR DESCRIPTION
Désactivation de Turbo sur les formulaires de connexion.
Turbo interceptait la soumission du formulaire de connexion, mais ne générait pas correctement la redirection qui suit avec obligation d'actualiser manuellement la page.