### PR TITLE
Fix dropdown issue in the dashboard

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,4 +1,4 @@
 import "@hotwired/turbo-rails";
 import "controllers";
-import "bootstrap";
-import "@popperjs/core";
+// import "bootstrap";
+// import "@popperjs/core";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,4 +19,28 @@
     <%= render "shared/flashes" %>
     <%= yield %>
   </body>
+
+  <script>
+  document.addEventListener('turbo:load', function() {
+    // Réinitialiser tous les composants dropdown/collapse
+    document.querySelectorAll('[data-bs-toggle]').forEach(element => {
+      element.addEventListener('click', function() {
+        // Assurer que les clics fonctionnent même après navigation Turbo
+        if (this.getAttribute('data-bs-toggle') === 'collapse') {
+          const targetId = this.getAttribute('data-bs-target');
+          const target = document.querySelector(targetId);
+
+          // Toggle manuellement si nécessaire
+          if (!target.classList.contains('collapsing')) {
+            if (target.classList.contains('show')) {
+              new bootstrap.Collapse(target).hide();
+            } else {
+              new bootstrap.Collapse(target).show();
+            }
+          }
+        }
+      }, { capture: true });
+    });
+  });
+</script>
 </html>


### PR DESCRIPTION
Les menus déroulants ne fonctionnaient pas correctement sur le dashboard.

Résolution : Utilisation uniquement de la version CDN de Bootstrap pour éviter les conflits, et ajout d'un script personnalisé pour réinitialiser les comportements des composants après navigation Turbo dans `application.html.erb`.