### PR TITLE
Fix profile photo import issue

### DIFF
--- a/app/views/freelancer/profiles/new.html.erb
+++ b/app/views/freelancer/profiles/new.html.erb
@@ -48,7 +48,7 @@
                         label: "Availability", input_html: { class: "form-control" } %>
         </div>
         <div class="mb-3">
-          <%= f.input :avatar, as: :file, label: "Profile Photo", input_html: { class: "form-control" } %>
+          <%= f.input :photo, as: :file, label: "Profile Photo", input_html: { class: "form-control" } %>
         </div>
 
         <hr class="my-4">


### PR DESCRIPTION
La photo de profil n'était pas correctement importée lors de la création d'un profil freelance.
Le modèle Profile utilise `has_one_attached :photo` mais le formulaire utilisait `f.input :avatar`.